### PR TITLE
Update git-icdiff to support pipes in git pager

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -13,4 +13,4 @@ if [ "$GITPAGER" = "more" -o "$GITPAGER" = "less" ]; then
   GITPAGER="$GITPAGER -R"
 fi
 
-git difftool --no-prompt --extcmd icdiff "$@" | $GITPAGER
+git difftool --no-prompt --extcmd icdiff "$@" | eval $GITPAGER


### PR DESCRIPTION
Hey,

I'm using this in my git config file:

```
[core]
    pager = /usr/local/share/git-core/contrib/diff-highlight/diff-highlight | less -r
```

This allows me to have diff like this:

<img width="409" alt="capture d ecran 2015-09-01 a 17 55 48" src="https://cloud.githubusercontent.com/assets/351471/9609232/eed38bac-50d2-11e5-804f-0fa8c2ab36ac.png">

And with this config, when I use `git icdiff` I get this error: `Missing command in piped open at /usr/local/opt/git/share/git-core/contrib/diff-highlight/diff-highlight line 32.`

Adding the call to `eval` make it work. I know eval is generally not something we want to do but I think the data from the gitconfig file could be considered safe, and I did not find any other solution. If someone has any other idea, please let me know.

Thanks.
